### PR TITLE
Emit language specific topic sections in the markdown representation of automatic curation

### DIFF
--- a/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
+++ b/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
@@ -199,7 +199,7 @@ public struct GeneratedCurationWriter {
         
         guard topicsByLanguage.count > 1 else {
             // If this node doesn't have curation in more than one language, return that curation _without_ a language filter.
-            return topicsByLanguage.first?.value.map { .init(title: $0.title ?? "Symbols", references: $0.references) }
+            return topicsByLanguage.first?.value.map { .init(title: $0.title! /* Automatically-generated task groups always have a title. */, references: $0.references) }
         }
         
         // Checks if a node for the given reference is only available in the given source language.
@@ -214,7 +214,8 @@ public struct GeneratedCurationWriter {
                 topicsByLanguage[language]?
                     .first(where: { $0.title == title })
                     .map { (title, references) in
-                        GeneratedTaskGroup(title: title ?? "Symbols", references: references, languageFilter: language)
+                        // Automatically-generated task groups always have a title.
+                        GeneratedTaskGroup(title: title!, references: references, languageFilter: language)
                     }
             }
             guard taskGroups.count > 1 else {

--- a/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
+++ b/Sources/SwiftDocC/Catalog Processing/GeneratedCurationWriter.swift
@@ -39,25 +39,15 @@ public struct GeneratedCurationWriter {
     func defaultCurationText(for reference: ResolvedTopicReference) -> String? {
         guard let node = context.documentationCache[reference],
               let symbol = node.semantic as? Symbol,
-              let automaticTopics = try? AutomaticCuration.topics(for: node, withTraits: [], context: context),
-              !automaticTopics.isEmpty
+              let taskGroups = taskGroupsToWrite(for: node)
         else {
             return nil
         }
         
         let relativeLinks = linkResolver.disambiguatedRelativeLinksForDescendants(of: reference)
         
-        // Top-level curation has a few special behaviors regarding symbols with different representations in multiple languages.
-        let isForTopLevelCuration = symbol.kind.identifier == .module
-        
         var text = ""
-        for taskGroup in automaticTopics {
-            if isForTopLevelCuration, let firstReference = taskGroup.references.first, context.documentationCache[firstReference]?.symbol?.kind.identifier == .typeProperty {
-                // Skip type properties in top-level curation. It's not clear what's the right place for these symbols are since they exist in
-                // different places in different source languages (which documentation extensions don't yet have a way of representing).
-                continue
-            }
-            
+        for taskGroup in taskGroups {
             let links: [(link: String, comment: String?)] = taskGroup.references.compactMap { (curatedReference: ResolvedTopicReference) -> (String, String?)? in
                 guard let linkInfo = relativeLinks[curatedReference] else { return nil }
                 // If this link contains disambiguation, include a comment with the full symbol declaration to make it easier to know which symbol the link refers to.
@@ -73,7 +63,10 @@ public struct GeneratedCurationWriter {
             
             guard !links.isEmpty else { continue }
             
-            text.append("\n\n### \(taskGroup.title ?? "<!-- This auto-generated topic has no title -->")\n")
+            text.append("\n\n### \(taskGroup.title)\n")
+            if let language = taskGroup.languageFilter {
+                text.append("\n@SupportedLanguage(\(language.taskGroupID))\n")
+            }
             
             // Calculate the longest link to nicely align all the comments
             let longestLink = links.map(\.link.count).max()! // `links` are non-empty so it's safe to force-unwrap `.max()` here
@@ -179,5 +172,104 @@ public struct GeneratedCurationWriter {
         }
         
         return contentsToWrite
+    }
+    
+    private struct GeneratedTaskGroup: Equatable {
+        var title: String
+        var references: [ResolvedTopicReference]
+        var languageFilter: SourceLanguage?
+    }
+    
+    private func taskGroupsToWrite(for node: DocumentationNode) -> [GeneratedTaskGroup]? {
+        // Perform source-language specific curation in a stable order
+        let languagesToCurate = node.availableSourceLanguages.sorted(by: { lhs, rhs in
+            // Sort Swift before other languages
+            if lhs == .swift {
+                return true
+            } else if rhs == .swift {
+                return false
+            }
+            // Otherwise, sort by ID for a stable order
+            return lhs.id < rhs.id
+        })
+        var topicsByLanguage = [SourceLanguage: [AutomaticCuration.TaskGroup]]()
+        for language in languagesToCurate {
+            topicsByLanguage[language] = try? AutomaticCuration.topics(for: node, withTraits: [.init(interfaceLanguage: language.id)], context: context)
+        }
+        
+        guard topicsByLanguage.count > 1 else {
+            // If this node doesn't have curation in more than one language, return that curation _without_ a language filter.
+            return topicsByLanguage.first?.value.map { .init(title: $0.title ?? "Symbols", references: $0.references) }
+        }
+        
+        // Checks if a node for the given reference is only available in the given source language.
+        func isOnlyAvailableIn(_ reference: ResolvedTopicReference, _ language: SourceLanguage) -> Bool {
+            context.documentationCache[reference]?.availableSourceLanguages == [language]
+        }
+        
+        // This is defined as an inner function so that the taskGroups-loop can return to finish processing task groups for that symbol kind.
+        func addProcessedTaskGroups(_ symbolKind: SymbolGraph.Symbol.KindIdentifier, into result: inout [GeneratedTaskGroup]) {
+            let title = AutomaticCuration.groupTitle(for: symbolKind)
+            let taskGroups: [GeneratedTaskGroup] = languagesToCurate.compactMap { language in
+                topicsByLanguage[language]?
+                    .first(where: { $0.title == title })
+                    .map { (title, references) in
+                        GeneratedTaskGroup(title: title ?? "Symbols", references: references, languageFilter: language)
+                    }
+            }
+            guard taskGroups.count > 1 else {
+                if let taskGroup = taskGroups.first {
+                    if taskGroup.references.allSatisfy({ isOnlyAvailableIn($0, taskGroup.languageFilter!) }) {
+                        // These symbols are all only available in one source language. We can omit the language filter.
+                        result.append(.init(title: title, references: taskGroup.references))
+                    } else {
+                        // Add the task group as-is, with its language filter.
+                        result.append(taskGroup)
+                    }
+                }
+                return
+            }
+            
+            // Check if the source-language specific task groups need to be emitted individually
+            for taskGroup in taskGroups {
+                // Gather all the references for the other task groups
+                let otherReferences = taskGroups.reduce(into: Set(), { accumulator, group in
+                    guard group != taskGroup else { return }
+                    accumulator.formUnion(group.references)
+                })
+                let uniqueReferences = Set(taskGroup.references).subtracting(otherReferences)
+                
+                guard uniqueReferences.isEmpty || uniqueReferences.allSatisfy({ isOnlyAvailableIn($0, taskGroup.languageFilter!) }) else {
+                    // If at least one of the task groups contains a a language-refined symbol that's not in the other task groups, then emit all task groups individually
+                    result.append(contentsOf: taskGroups)
+                    return
+                }
+            }
+            
+            // Otherwise, if the task groups all contain the same symbols or only contain single-language symbols, emit a combined task group without a language filter.
+            // When DocC renders this task group it will filter out the single-language symbols, producing correct and consistent results in all language variants without
+            // needing to repeat the task groups with individual language filters.
+            result.append(.init(
+                title: title,
+                references: taskGroups.reduce(into: Set(), { $0.formUnion($1.references) }).sorted(by: \.path)
+            ))
+        }
+        
+        var result = [GeneratedTaskGroup]()
+        for symbolKind in AutomaticCuration.groupKindOrder {
+            addProcessedTaskGroups(symbolKind, into: &result)
+        }
+        return result
+    }
+}
+
+private extension SourceLanguage {
+    var taskGroupID: String {
+        switch self {
+        case .objectiveC:
+            return "objc"
+        default:
+            return self.linkDisambiguationID
+        }
     }
 }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy+DisambiguatedPaths.swift
@@ -92,8 +92,8 @@ extension PathHierarchy {
             nameTransform = { $0 }
         }
         
-        func descend(_ node: Node, accumulatedPath: String) -> [(String, (String, Bool))] {
-            var results: [(String, (String, Bool))] = []
+        func descend(_ node: Node, accumulatedPath: String) -> [String: String] {
+            var innerPathsByUSR: [String: String] = [:]
             let children = [String: DisambiguationContainer](node.children.map {
                 var name = $0.key
                 if !caseSensitive {
@@ -102,8 +102,8 @@ extension PathHierarchy {
                 return (nameTransform(name), $0.value)
             }, uniquingKeysWith: { $0.merge(with: $1) })
             
-            for (_, tree) in children {
-                let disambiguatedChildren = tree.disambiguatedValuesWithCollapsedUniqueSymbols(includeLanguage: includeLanguage)
+            for (_, container) in children {
+                let disambiguatedChildren = container.disambiguatedValuesWithCollapsedUniqueSymbols(includeLanguage: includeLanguage)
                 let uniqueNodesWithChildren = Set(disambiguatedChildren.filter { $0.disambiguation.value() != nil && !$0.value.children.isEmpty }.map { $0.value.symbol?.identifier.precise })
                 
                 for (node, disambiguation) in disambiguatedChildren {
@@ -112,7 +112,7 @@ extension PathHierarchy {
                         // When descending through placeholder nodes, we trust that the known disambiguation
                         // that they were created with is necessary.
                         var knownDisambiguation = ""
-                        let element = tree.storage.first!
+                        let element = container.storage.first!
                         if let kind = element.kind {
                             knownDisambiguation += "-\(kind)"
                         }
@@ -123,37 +123,39 @@ extension PathHierarchy {
                     } else {
                         path = accumulatedPath + "/" + nameTransform(node.name)
                     }
-                    if let symbol = node.symbol {
-                        results.append(
-                            (symbol.identifier.precise, (path + disambiguation.makeSuffix(), symbol.identifier.interfaceLanguage == "swift"))
-                        )
+                    if let symbol = node.symbol,
+                       // If a symbol node exist in multiple languages, prioritize the Swift variant.
+                       node.counterpart == nil || symbol.identifier.interfaceLanguage == "swift"
+                    {
+                        innerPathsByUSR[symbol.identifier.precise] = path + disambiguation.makeSuffix()
                     }
                     if includeDisambiguationForUnambiguousChildren || uniqueNodesWithChildren.count > 1 {
                         path += disambiguation.makeSuffix()
                     }
-                    results += descend(node, accumulatedPath: path)
+                    innerPathsByUSR.merge(descend(node, accumulatedPath: path), uniquingKeysWith: { currentPath, newPath in
+                        assertionFailure("Should only have gathered one path per symbol ID. Found \(currentPath) and \(newPath) for the same USR.")
+                        return currentPath
+                    })
                 }
             }
-            return results
+            return innerPathsByUSR
         }
         
-        var gathered: [(String, (String, Bool))] = []
+        var pathsByUSR: [String: String] = [:]
         
         for node in modules {
-            let path = "/" + node.name
-            gathered.append(
-                (node.name, (path, node.symbol == nil || node.symbol!.identifier.interfaceLanguage == "swift"))
-            )
-            gathered += descend(node, accumulatedPath: path)
+            let modulePath = "/" + node.name
+            pathsByUSR[node.name] = modulePath
+            pathsByUSR.merge(descend(node, accumulatedPath: modulePath), uniquingKeysWith: { currentPath, newPath in
+                assertionFailure("Should only have gathered one path per symbol ID. Found \(currentPath) and \(newPath) for the same USR.")
+                return currentPath
+            })
         }
         
-        // If a symbol node exist in multiple languages, prioritize the Swift variant.
-        let result = [String: (String, Bool)](gathered, uniquingKeysWith: { lhs, rhs in lhs.1 ? lhs : rhs }).mapValues({ $0.0 })
-        
         assert(
-            Set(result.values).count == result.keys.count,
+            Set(pathsByUSR.values).count == pathsByUSR.keys.count,
             {
-                let collisionDescriptions = result
+                let collisionDescriptions = pathsByUSR
                     .reduce(into: [String: [String]](), { $0[$1.value, default: []].append($1.key) })
                     .filter({ $0.value.count > 1 })
                     .map { "\($0.key)\n\($0.value.map({ "  " + $0 }).joined(separator: "\n"))" }
@@ -164,7 +166,7 @@ extension PathHierarchy {
             }()
         )
         
-        return result
+        return pathsByUSR
     }
 }
 

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -74,7 +74,7 @@ final class PathHierarchyBasedLinkResolver {
                 container.storage.compactMap { element in
                     guard let childID = element.node.identifier, // Don't include sparse nodes
                           !element.node.isDisfavoredInCollision, // Don't include disfavored collisions
-                          !element.node.languages.isDisjoint(with: languagesFilter)
+                          languagesFilter.isEmpty || !element.node.languages.isDisjoint(with: languagesFilter) 
                     else {
                         return nil
                     }
@@ -87,7 +87,7 @@ final class PathHierarchyBasedLinkResolver {
         if node.languages.isSuperset(of: languagesFilter) {
             results.formUnion(directDescendants(of: node))
         }
-        if let counterpart = node.counterpart, counterpart.languages.isSubset(of: languagesFilter) {
+        if let counterpart = node.counterpart, counterpart.languages.isSuperset(of: languagesFilter) {
             results.formUnion(directDescendants(of: counterpart))
         }
         return results

--- a/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
+++ b/Sources/SwiftDocC/Infrastructure/Symbol Graph/GeneratedDocumentationTopics.swift
@@ -175,18 +175,7 @@ enum GeneratedDocumentationTopics {
             )
         }
 
-        // Create a temp node in order to generate the automatic curation
-        let temporaryCollectionNode = DocumentationNode(
-            reference: collectionReference,
-            kind: .collectionGroup,
-            sourceLanguage: automaticCurationSourceLanguage,
-            availableSourceLanguages: automaticCurationSourceLanguages,
-            name: DocumentationNode.Name.conceptual(title: title),
-            markup: Document(parsing: ""),
-            semantic: Article(markup: nil, metadata: nil, redirects: nil, options: [:])
-        )
-        
-        let collectionTaskGroups = try AutomaticCuration.topics(for: temporaryCollectionNode, withTraits: [], context: context)
+        let collectionTaskGroups = try AutomaticCuration.topics(for: identifiers, inInheritedSymbolsAPICollection: true, withTraits: [], context: context)
             .map { taskGroup in
                 AutomaticTaskGroupSection(
                     // Force-unwrapping the title since automatically-generated task groups always have a title.

--- a/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
+++ b/Sources/SwiftDocC/Infrastructure/Topic Graph/AutomaticCuration.swift
@@ -40,11 +40,12 @@ public struct AutomaticCuration {
     /// Automatic curation task group.
     typealias TaskGroup = (title: String?, references: [ResolvedTopicReference])
     
-    /// Returns a list of automatically curated Topics task groups for the given documentation node.
+    /// Returns a list of "automatic curation" task groups, organized by their symbol kind or page kind, with the given traits for the given documentation node.
     /// - Parameters:
-    ///   - node: A node for which to generate topics groups.
-    ///   - context: A documentation context.
-    /// - Returns: An array of title and references list tuples.
+    ///   - node: The node to generate "automatic curation" task groups for.
+    ///   - variantsTraits: The variant traits to filter the automatic curation task groups for.
+    ///   - context: The context to lookup entities and topic graph edges in.
+    /// - Returns: A list of title and references pairs.
     static func topics(
         for node: DocumentationNode,
         withTraits variantsTraits: Set<DocumentationDataVariantsTrait>,
@@ -54,39 +55,33 @@ public struct AutomaticCuration {
             $0.interfaceLanguage.map { SourceLanguage(id: $0) }
         })
         
-        let children: [ResolvedTopicReference]
-        if languagesFilter.isEmpty {
-            // If the caller requests a combined topic section for all source languages, then the results from the `TopicGraph` will be accurate.
-            
-            // Get any default implementation relationships for this symbol
-            //
-            // It's okay to include all variants here because we just use this set to filter
-            // out these values from automatic curation.
-            let defaultImplementationReferences = Set<String>(
-                (node.semantic as? Symbol)?.defaultImplementationsVariants.allValues
-                    .lazy
-                    .map(\.variant)
-                    .flatMap(\.implementations)
-                    .compactMap { implementation in
-                        implementation.reference.url?.absoluteString
-                    } ?? []
-            )
-            
-            children = context.children(of: node.reference)
-                // Remove any default implementations
-                .filter({ reference, _ -> Bool in
-                    return !defaultImplementationReferences.contains(reference.absoluteString)
-                })
-                .map(\.reference)
-        } else {
-            // If the caller requests topic section for a subset of source languages, then the `TopicGraph` is incapable of producing correct results
-            // because it considers all relationships in all languages. Instead we ask the `PathHierarchy` which is source-language-aware.
-            children = context.linkResolver.localResolver.directDescendants(of: node.reference, languagesFilter: languagesFilter)
-                .sorted(by: \.path)
-        }
+        // Because the `TopicGraph` uses the same nodes for both language representations and doesn't have awareness of language specific edges,
+        // it can't correctly determine language specific automatic curation. Instead we ask the `PathHierarchy` which is source-language-aware.
+        let children = context.linkResolver.localResolver.directDescendants(of: node.reference, languagesFilter: languagesFilter)
+            .sorted(by: \.path)
         
-        return try children
-            // Force unwrapping as all nodes need to be valid in the rendering phase of the pipeline.
+        return try topics(
+            for: children,
+            inInheritedSymbolsAPICollection: GeneratedDocumentationTopics.isInheritedSymbolsAPICollectionNode(node.reference, in: context.topicGraph),
+            withTraits: variantsTraits,
+            context: context
+        )
+    }
+    
+    /// Organizes the given list of references into "automatic curation" task groups based on their symbol kind or page kind.
+    /// - Parameters:
+    ///   - references: The list of references to organize into "automatic curation" task groups.
+    ///   - inInheritedSymbolsAPICollection: Whether or not this automatic curation is for a "inherited symbols" API collection.
+    ///   - variantsTraits: The variant traits to filter the automatic curation task groups for.
+    ///   - context: The context to lookup entities and topic graph edges in.
+    /// - Returns: A list of title and references pairs.
+    static func topics(
+        for references: [ResolvedTopicReference],
+        inInheritedSymbolsAPICollection: Bool,
+        withTraits variantsTraits: Set<DocumentationDataVariantsTrait>,
+        context: DocumentationContext
+    ) throws -> [TaskGroup] {
+        try references
             .reduce(into: AutomaticCuration.groups) { groupsIndex, reference in
                 guard let topicNode = context.topicGraph.nodeWithReference(reference),
                       !topicNode.isEmptyExtension,
@@ -95,8 +90,8 @@ public struct AutomaticCuration {
                     return
                 }
                 
-                // Skip members of "inherited" API collections unless this node is an Inherited API collection.
-                guard GeneratedDocumentationTopics.isInheritedSymbolsAPICollectionNode(node.reference, in: context.topicGraph)
+                // Skip members of "inherited" API collections unless the automatic curation is for an Inherited API collection.
+                guard inInheritedSymbolsAPICollection
                    || !(context.topicGraph.reverseEdges[reference] ?? []).contains(where: { GeneratedDocumentationTopics.isInheritedSymbolsAPICollectionNode($0, in: context.topicGraph) })
                 else {
                     return

--- a/Tests/SwiftDocCTests/Catalog Processing/GeneratedCurationWriterTests.swift
+++ b/Tests/SwiftDocCTests/Catalog Processing/GeneratedCurationWriterTests.swift
@@ -46,6 +46,8 @@ class GeneratedCurationWriterTests: XCTestCase {
 
         ### Structures
 
+        @SupportedLanguage(swift)
+
         - ``MyObjectiveCOption``
         - ``MyStruct``
         - ``MyTypedObjectiveCEnum``
@@ -53,9 +55,20 @@ class GeneratedCurationWriterTests: XCTestCase {
 
         ### Variables
 
+        @SupportedLanguage(swift)
+
+        - ``myTopLevelVariable``
+
+        ### Variables
+
+        @SupportedLanguage(objc)
+
         - ``MixedFrameworkVersionNumber``
         - ``MixedFrameworkVersionString``
-        - ``myTopLevelVariable``
+        - ``MyTypedObjectiveCEnumFirst``
+        - ``MyTypedObjectiveCEnumSecond``
+        - ``MyTypedObjectiveCExtensibleEnumFirst``
+        - ``MyTypedObjectiveCExtensibleEnumSecond``
 
         ### Functions
 
@@ -63,9 +76,20 @@ class GeneratedCurationWriterTests: XCTestCase {
 
         ### Type Aliases
 
+        @SupportedLanguage(swift)
+
         - ``MyTypeAlias``
 
+        ### Type Aliases
+
+        @SupportedLanguage(objc)
+
+        - ``MyTypedObjectiveCEnum``
+        - ``MyTypedObjectiveCExtensibleEnum``
+
         ### Enumerations
+
+        @SupportedLanguage(swift)
 
         - ``CollisionsWithDifferentFunctionArguments``
         - ``CollisionsWithDifferentKinds``
@@ -73,6 +97,15 @@ class GeneratedCurationWriterTests: XCTestCase {
         - ``MyEnum``
         - ``MyObjectiveCEnum``
         - ``MyObjectiveCEnumSwiftName``
+
+        ### Enumerations
+
+        @SupportedLanguage(objc)
+
+        - ``MyEnum``
+        - ``MyObjectiveCEnum``
+        - ``MyObjectiveCEnumSwiftName``
+        - ``MyObjectiveCOption``
         
         """)
     }
@@ -311,6 +344,99 @@ class GeneratedCurationWriterTests: XCTestCase {
         
         """)
     }
+    
+    func testGeneratingLanguageSpecificCuration() throws {
+        let (url, _, context) = try testBundleAndContext(named: "GeometricalShapes")
+        
+        let writer = try XCTUnwrap(GeneratedCurationWriter(context: context, catalogURL: url, outputURL: testOutputURL))
+        let contentsToWrite = try writer.generateDefaultCurationContents()
+        
+        XCTAssertEqual(contentsToWrite.count, 2)
+        
+        // In Objective-C, the Circle API appear as top level variables and functions.
+        XCTAssertEqual(contentsToWrite[testOutputURL.appendingPathComponent("GeometricalShapes.md")], """
+        # ``/GeometricalShapes``
+
+        <!-- The content below this line is auto-generated and is redundant. You should either incorporate it into your content above this line or delete it. -->
+
+        ## Topics
+
+        ### Structures
+
+        - ``Circle``
+
+        ### Variables
+
+        @SupportedLanguage(objc)
+
+        - ``TLACircleDefaultRadius``
+        - ``TLACircleNull``
+        - ``TLACircleZero``
+
+        ### Functions
+
+        @SupportedLanguage(objc)
+
+        - ``TLACircleToString``
+        - ``TLACircleFromString``
+        - ``TLACircleIntersects``
+        - ``TLACircleIsEmpty``
+        - ``TLACircleIsNull``
+        - ``TLACircleMake``
+
+        """)
+        
+        // In Swift, the Circle API appear as members of the Circle structure.
+        // There are two "Instance Properties" task groups because both Swift and Objective-C has it and the extra symbols exist in both languages.
+        XCTAssertEqual(contentsToWrite[testOutputURL.appendingPathComponent("GeometricalShapes/Circle.md")], """
+        # ``/GeometricalShapes/Circle``
+
+        <!-- The content below this line is auto-generated and is redundant. You should either incorporate it into your content above this line or delete it. -->
+
+        ## Topics
+
+        ### Initializers
+
+        @SupportedLanguage(swift)
+
+        - ``init()``
+        - ``init(center:radius:)``
+        - ``init(string:)``
+
+        ### Instance Properties
+
+        @SupportedLanguage(swift)
+
+        - ``center``
+        - ``debugDescription``
+        - ``isEmpty``
+        - ``isNull``
+        - ``radius``
+
+        ### Instance Properties
+
+        @SupportedLanguage(objc)
+
+        - ``center``
+        - ``radius``
+
+        ### Instance Methods
+
+        @SupportedLanguage(swift)
+
+        - ``intersects(_:)``
+
+        ### Type Properties
+
+        @SupportedLanguage(swift)
+
+        - ``defaultRadius``
+        - ``null``
+        - ``zero``
+        
+        """)
+    }
+    
     
     func testCustomOutputLocation() throws {
         let (url, _, context) = try testBundleAndContext(named: "MixedLanguageFrameworkWithLanguageRefinements")


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://124527905

## Summary

This builds on #854 to emit language specific topic sections in the markdown representation of automatic curation from `docc process-catalog emit-generated-curation`

## Dependencies

#854

## Testing

Run `docc process-catalog emit-generated-curation` on a project with language refinements (for example " Tests/SwiftDocCTests/Test Bundles/GeometricalShapes.docc"

Symbols that appear in different places in different languages should be listed in language specific topic sections.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary
